### PR TITLE
Change Calibre version check to use Github

### DIFF
--- a/linux/calibre-upgrade.sh
+++ b/linux/calibre-upgrade.sh
@@ -73,7 +73,8 @@ fi
 
 
 if calibre_is_installed; then
-    LATESTCALIBREVERS=`curl --silent --max-time 10 https://api.github.com/repos/kovidgoyal/calibre/releases/latest | jq --raw-output '.tag_name' | cut -c2-6 -`
+    LATESTCALIBREVERS=`curl --silent --max-time 10 https://api.github.com/repos/kovidgoyal/calibre/releases/latest | jq --raw-output '.tag_name'`
+    LATESTCALIBREVERS=${LATESTCALIBREVERS:1}
     calibre-debug -c "from calibre.constants import numeric_version; raise SystemExit(int(numeric_version  < (tuple(map(int, '$LATESTCALIBREVERS'.split('.'))))))"
     UP_TO_DATE=$?
 else

--- a/linux/calibre-upgrade.sh
+++ b/linux/calibre-upgrade.sh
@@ -73,7 +73,8 @@ fi
 
 
 if calibre_is_installed; then
-    calibre-debug -c "import urllib as u; from calibre.constants import numeric_version; raise SystemExit(int(numeric_version  < (tuple(map(int, u.urlopen('http://code.calibre-ebook.com/latest').read().split('.'))))))"
+    LATESTCALIBREVERS=`curl --silent --max-time 10 https://api.github.com/repos/kovidgoyal/calibre/releases/latest | jq --raw-output '.tag_name' | cut -c2-6 -`
+    calibre-debug -c "from calibre.constants import numeric_version; raise SystemExit(int(numeric_version  < (tuple(map(int, '$LATESTCALIBREVERS'.split('.'))))))"
     UP_TO_DATE=$?
 else
     echo -e "Calibre is not installed, installing...\n\n"


### PR DESCRIPTION
The script at https://github.com/eli-schwartz/calibre-installer relies on this page to do the update check:
http://code.calibre-ebook.com/latest

But for the last week or so that page or site was sometimes down (404 error) and it still has an invalid certificate which causes exceptions. I've written a slightly altered script which uses Github's REST API to check the version, since github.com is less likely to go down than the above